### PR TITLE
Shorten fuse

### DIFF
--- a/data/danielrh/functions/acg/defuse.mcfunction
+++ b/data/danielrh/functions/acg/defuse.mcfunction
@@ -6,7 +6,10 @@ data modify entity @s ActiveEffects append value {Duration: 2147483637, Id: 27b,
 # Shorten fuse by 1 tick, since we delay the actual explosion
 execute store result score @s drh_acg_fuse run data get entity @s Fuse
 scoreboard players remove @s drh_acg_fuse 1
-execute store result entity @s Fuse byte 1 run scoreboard players get @s drh_acg_fuse
+
+# The if clause is because on the first tick of the datapack being loaded, the
+# scoreboard wonʼt exist yet.  Old creepers wonʼt have shortened fuses.
+execute if score @s drh_acg_fuse matches 1.. store result entity @s Fuse byte 1 run scoreboard players get @s drh_acg_fuse
 scoreboard players reset @s drh_acg_fuse
 
 tag @s add acg_defused

--- a/data/danielrh/functions/acg/defuse.mcfunction
+++ b/data/danielrh/functions/acg/defuse.mcfunction
@@ -1,6 +1,12 @@
 # Make 17x lucky and 17x unlucky, and nonexplosive
-# TODO: Shorten fuse by 1 tick, since we delay the actual explosion
 data merge entity @s {ExplosionRadius: 0b}
 data modify entity @s ActiveEffects append value {Duration: 2147483637, Id: 26b, Amplifier: 17b, Ambient: false, ShowParticles: false, ShowIcon: true}
 data modify entity @s ActiveEffects append value {Duration: 2147483637, Id: 27b, Amplifier: 17b, Ambient: true, ShowParticles: false, ShowIcon: true}
+
+# Shorten fuse by 1 tick, since we delay the actual explosion
+execute store result score @s drh_acg_fuse run data get entity @s Fuse
+scoreboard players remove @s drh_acg_fuse 1
+execute store result entity @s Fuse byte 1 run scoreboard players get @s drh_acg_fuse
+scoreboard players reset @s drh_acg_fuse
+
 tag @s add acg_defused

--- a/data/danielrh/functions/acg/init.mcfunction
+++ b/data/danielrh/functions/acg/init.mcfunction
@@ -1,0 +1,1 @@
+scoreboard objectives add drh_acg_fuse dummy "Temporary fuse variable for DanielRH Anti-Creeper Griefing datapack"

--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,0 +1,3 @@
+{
+	"values": ["danielrh:acg/init"]
+}


### PR DESCRIPTION
This fixes #7, but it does so in a bit of a weird way because of the check to see if the scoreboard actually exists.  Should probably be revisited after #6, since that will add an easy check for if the thingʼs enabled.

Although maybe the current check should still exist?  I donʼt want to make this pack explode 1-tick fuse creepers instantly.